### PR TITLE
Bump golang version to 1.16.x

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ parts:
     go-importpath: github.com/hashicorp/vault
     go-buildtags:
       - vault
-    go-channel: 1.15/stable
+    go-channel: 1.16/stable
     build-packages:
       - git
       - g++


### PR DESCRIPTION
Bump the golang version used for the vault build to 1.16.x.

This resolves CVE-2021-44716 - for more information see

 https://groups.google.com/g/golang-announce/c/hcmEScgc00k?pli=1