### PR TITLE
move snap to the core22 base, strip binaries (fixes #32)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   is already very difficult and platform-specific. Adding on key rolling,
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
-base: core20
+base: core22
 
 grade: stable
 confinement: strict
@@ -25,19 +25,22 @@ parts:
   vault:
     source: https://github.com/hashicorp/vault.git
     override-pull: |
-      set -x
-      snapcraftctl pull
+      craftctl default
+      echo ----------
+      env | grep CRAFT
+      echo ----------
       release_tag="$(git tag -l --sort=version:refname "v1.11.*" | tail -1)"
       # If the latest tag from the upstream project has not been released to
       git checkout "${release_tag}"
-      git apply $SNAPCRAFT_STAGE/etcd_export_tls_no_verify.patch
-      snapcraftctl set-version `echo ${release_tag} | sed "s/v//g"`
+      git apply $CRAFT_PROJECT_DIR/snap/local/patches/etcd_export_tls_no_verify.patch
+      craftctl set version=`echo ${release_tag} | sed "s/v//g"`
       go mod download -x
     plugin: go
     go-buildtags:
       - vault
       - ui
-    go-channel: 1.17/stable
+    build-snaps:
+      - go/1.17/stable
     build-packages:
       - git
       - g++
@@ -62,7 +65,9 @@ parts:
           make static-dist
       fi
       # Complete the main go build
-      snapcraftctl build
+      craftctl default
+      # Manually strip binaries
+      strip -s $CRAFT_PART_INSTALL/bin/*
   patches:
     source: ./snap/local/patches
     plugin: dump


### PR DESCRIPTION
Snap size has now decreased from 295MB to 152MB