### PR TITLE
Add service capability to vault snap

### DIFF
--- a/snap-common/bin/vaultd-reload
+++ b/snap-common/bin/vaultd-reload
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -ex
+
+vault_pid=$(pgrep -x vault)
+
+if [ -n "$vault_pid" ]; then
+    kill -s HUP "$vault_pid"
+fi

--- a/snap-common/bin/vaultd-start
+++ b/snap-common/bin/vaultd-start
@@ -1,0 +1,39 @@
+#!/bin/bash -x
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+VAULT_TEMPLATES_FILE=(
+    "vault.hcl"
+    "vault.env"
+)
+
+for template in "${VAULT_TEMPLATES_FILE[@]}"; do
+    CONFIG_SRC="$SNAP/$template"
+    CONFIG_DST="$SNAP_DATA/$template"
+    CONFIG_COMMON="$SNAP_COMMON/$template"
+    if [ ! -f "$CONFIG_DST" ]; then
+    # Copy the default configuration file to the writable directory
+    cp "$CONFIG_SRC" "$CONFIG_DST"
+fi
+# NOTE: This is needed to make sure that the snap will have backwards compatibility with charm-vault that
+# expects the configuration file to be in /var/snap/vault/common/vault.hcl
+echo "# This file is managed by snap and it might be overwritten at any time." | \
+cat - "$CONFIG_DST" > "$SNAP_COMMON"/temp
+mv "$SNAP_COMMON"/temp "$CONFIG_COMMON"
+done
+
+source "$SNAP_COMMON"/vault.env
+"$SNAP"/bin/vault server -config "$SNAP_COMMON"/vault.hcl
+

--- a/snap-common/bin/vaultd-stop
+++ b/snap-common/bin/vaultd-stop
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Copyright (C) 2023 Canonical Ltd
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+set -ex
+
+vault_pid=$(pgrep -x vault)
+
+if [ -n "$vault_pid" ]; then
+    kill -s TERM "$vault_pid"
+fi

--- a/snap-common/vault.hcl
+++ b/snap-common/vault.hcl
@@ -1,0 +1,13 @@
+ui = true
+
+disable_mlock = true
+
+storage "file" {
+  path = "/var/snap/vault/common/data"
+}
+
+# HTTP listener
+listener "tcp" {
+  address       = "0.0.0.0:8200"
+  tls_disable   = 1
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core22
-version: 1.12.3
+version: 1.13.0
 
 grade: stable
 confinement: strict
@@ -20,6 +20,17 @@ apps:
       - network
       - network-bind
       - home
+  vaultd:
+    daemon: simple
+    command: bin/vaultd-start
+    refresh-mode: endure
+    reload-command: bin/vaultd-reload
+    stop-command: bin/vaultd-stop
+    restart-condition: on-failure
+    stop-mode: sigterm
+    plugs:
+      - network
+      - network-bind
 
 parts:
   vault:
@@ -65,6 +76,10 @@ parts:
       craftctl default
       # Manually strip binaries
       strip -s $CRAFT_PART_INSTALL/bin/*
+  deps:
+    plugin: dump
+    source: snap-common
+
   patches:
     source: ./snap/local/patches
     plugin: dump


### PR DESCRIPTION
Since vault is mostly used as a server, it makes sense to provide a 'vault server' in the snap.