### PR TITLE
chore: Adds TLS team as code owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @canonical/tls


### PR DESCRIPTION
# Description

Adds the `canonical/tls` team as code owner so that the team is automatically assigned to reviewing PR's in this project.