### PR TITLE
chore: Bumps snap version to 1.12.11

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core22
-version: 1.12.3
+version: 1.12.11
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
# Description

Bumps vault version to 1.12.11. 

Note: Once this is merged, I will close PR #53 as the automation does not sign its commits.
