### PR TITLE
feat: Adds vault daemon service

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,18 @@ distributions.</p>
 
 ([Don't have snapd installed?](https://snapcraft.io/docs/core/install))
 
+## Usage
+
+### Service
+
+Edit the configuration file at `/var/snap/vault/common/vault.hcl` and start the service with:
+
+```shell
+sudo snap start vault.vaultd
+```
+
+### Client
+
+```shell
+vault status
+```

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+# Create Vault config file
+cp "$SNAP/vault.hcl" "$SNAP_COMMON/vault.hcl"
+cp "$SNAP/vault.env" "$SNAP_COMMON/vault.env"

--- a/snap/service/bin/vaultd-reload
+++ b/snap/service/bin/vaultd-reload
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+set -ex
+
+vault_pid=$(pgrep -x vault)
+
+if [ -n "$vault_pid" ]; then
+    kill -s HUP "$vault_pid"
+fi

--- a/snap/service/bin/vaultd-start
+++ b/snap/service/bin/vaultd-start
@@ -1,0 +1,7 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+set -ex
+
+source "$SNAP_COMMON"/vault.env
+"$SNAP"/bin/vault server -config "$SNAP_COMMON"/vault.hcl

--- a/snap/service/bin/vaultd-stop
+++ b/snap/service/bin/vaultd-stop
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Copyright (C) 2024 Canonical Ltd
+
+set -ex
+
+vault_pid=$(pgrep -x vault)
+
+if [ -n "$vault_pid" ]; then
+    kill -s TERM "$vault_pid"
+fi

--- a/snap/service/vault.hcl
+++ b/snap/service/vault.hcl
@@ -1,0 +1,13 @@
+ui = true
+
+disable_mlock = true
+
+storage "file" {
+  path = "/var/snap/vault/common/data"
+}
+
+# HTTP listener
+listener "tcp" {
+  address       = "0.0.0.0:8200"
+  tls_disable   = 1
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,6 +20,18 @@ apps:
       - network
       - network-bind
       - home
+  vaultd:
+    daemon: simple
+    install-mode: disable
+    command: bin/vaultd-start
+    refresh-mode: endure
+    reload-command: bin/vaultd-reload
+    stop-command: bin/vaultd-stop
+    restart-condition: on-failure
+    stop-mode: sigterm
+    plugs:
+      - network
+      - network-bind
 
 package-repositories:
  - type: apt
@@ -58,3 +70,7 @@ parts:
       craftctl default
       # Manually strip binaries
       strip -s $CRAFT_PART_INSTALL/bin/*
+
+  service-files:
+    plugin: dump
+    source: snap/service


### PR DESCRIPTION
# Description

This PR implements the Vault daemon service needed by the Vault machine charm and other use cases. 

## Usage

Edit the configuration file at `/var/snap/vault/common/vault.hcl`, then control the Vault service using snap commands:

```shell
sudo snap start vault.vaultd
sudo snap restart vault.vaultd
sudo snap stop vault.vaultd
```
## Note

This PR is in good part based on PR #52 with these added changes:
- Uses install hooks to copy configuration files
- Improvements to docs
- Signed Commit
- Follows PR linting validation


Fixes #48 