### PR TITLE
fix: Doesnt use package-repositories

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,12 +37,6 @@ parts:
   vault:
     source: https://github.com/hashicorp/vault.git
     source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
-    override-pull: |
-      craftctl default
-      echo ----------
-      env | grep CRAFT
-      echo ----------
-      go mod download -x
     plugin: go
     go-buildtags:
       - vault
@@ -50,7 +44,6 @@ parts:
     build-snaps:
       - go/1.21/stable
     build-packages:
-      - git
       - g++
       - libsasl2-dev
       - curl
@@ -58,15 +51,16 @@ parts:
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
-          # Install nodejs 14
-          REPO="https://deb.nodesource.com/node_14.x"
+          # Install nodejs 16
+          REPO="https://deb.nodesource.com/node_16.x"
           echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
           curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -
-          # Install yarn
-          echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-          curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
           apt-get update
-          apt-get install -y nodejs yarn=1.19.1-1
+          apt-get install -y nodejs
+
+          # Install yarn
+          npm install --global yarn
+
           # Build the WebUI assets
           make static-dist
       fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,6 +43,8 @@ parts:
       - ui
     build-snaps:
       - go/1.21/stable
+    build-packages:
+      - curl
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,8 +46,8 @@ parts:
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
-           # Install nodejs 14
-          REPO="https://deb.nodesource.com/node_14.x"
+           # Install nodejs 16
+          REPO="https://deb.nodesource.com/node_16.x"
           echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
           curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -50,19 +50,18 @@ parts:
       - curl
       - gnupg
     override-build: |
+      go mod download -x
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
-           # Install nodejs 14
+          # Install nodejs 14
           REPO="https://deb.nodesource.com/node_14.x"
           echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
           curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -
-
           # Install yarn
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
           curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
           apt-get update
           apt-get install -y nodejs yarn=1.19.1-1
-
           # Build the WebUI assets
           make static-dist
       fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
       - vault
       - ui
     build-snaps:
-      - go/1.19/stable
+      - go/1.21/stable
     build-packages:
       - git
       - g++

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,7 +49,7 @@ parts:
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
            # Install nodejs 16
-          REPO="https://deb.nodesource.com/node_16.x"
+          REPO="https://deb.nodesource.com/node_14.x"
           echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
           curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,7 +57,7 @@ parts:
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
           curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
           apt-get update
-          apt-get install -y nodejs yarn
+          apt-get install -y nodejs yarn=1.19.1-1
 
           # Build the WebUI assets
           make static-dist

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ parts:
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
-           # Install nodejs 16
+           # Install nodejs 14
           REPO="https://deb.nodesource.com/node_14.x"
           echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
           curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -37,12 +37,18 @@ parts:
   vault:
     source: https://github.com/hashicorp/vault.git
     source-tag: "v$SNAPCRAFT_PROJECT_VERSION"
+    override-pull: |
+      craftctl default
+      echo ----------
+      env | grep CRAFT
+      echo ----------
+      go mod download -x
     plugin: go
     go-buildtags:
       - vault
       - ui
     build-snaps:
-      - go/1.21/stable
+      - go/1.19/stable
     build-packages:
       - git
       - g++
@@ -50,7 +56,6 @@ parts:
       - curl
       - gnupg
     override-build: |
-      go mod download -x
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
           # Install nodejs 14
@@ -69,7 +74,3 @@ parts:
       craftctl default
       # Manually strip binaries
       strip -s $CRAFT_PART_INSTALL/bin/*
-
-  service-files:
-    plugin: dump
-    source: snap/service

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,20 +33,6 @@ apps:
       - network
       - network-bind
 
-package-repositories:
- - type: apt
-   url: https://deb.nodesource.com/node_16.x
-   components: [main]
-   suites: [focal]
-   key-server: https://deb.nodesource.com/gpgkey/nodesource.gpg.key
-   key-id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280
- - type: apt
-   url: https://dl.yarnpkg.com/debian/
-   components: [main]
-   suites: [stable]
-   key-server: https://dl.yarnpkg.com/debian/pubkey.gpg
-   key-id: 72ECF46A56B4AD39C907BBB71646B01B86E50310
-
 parts:
   vault:
     source: https://github.com/hashicorp/vault.git
@@ -57,12 +43,20 @@ parts:
       - ui
     build-snaps:
       - go/1.21/stable
-    build-packages:
-      - nodejs
-      - yarn
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then
+           # Install nodejs 14
+          REPO="https://deb.nodesource.com/node_14.x"
+          echo "deb $REPO focal main" > /etc/apt/sources.list.d/nodesource.list
+          curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | apt-key add -
+
+          # Install yarn
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+          curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+          apt-get update
+          apt-get install -y nodejs yarn
+
           # Build the WebUI assets
           make static-dist
       fi

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,7 +44,11 @@ parts:
     build-snaps:
       - go/1.21/stable
     build-packages:
+      - git
+      - g++
+      - libsasl2-dev
       - curl
+      - gnupg
     override-build: |
       DEB_TARGET_ARCH=`dpkg-architecture -qDEB_TARGET_ARCH`
       if [ "$DEB_TARGET_ARCH" = "amd64" ] || [ "$DEB_TARGET_ARCH" = "arm64" ]; then


### PR DESCRIPTION
# Description

We revert a change implemented in PR #60 where we started using `package-repositories`. The current build fails in launchpad because of this change.

## Logs

- [Launchpad build logs](https://launchpadlibrarian.net/710675410/buildlog_snap_ubuntu_jammy_amd64_vault-latest_BUILDING.txt.gz)