### PR TITLE
chore: Publish to snapcraft.io using Github workflow

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,12 +1,14 @@
-name: Master branch workflow
+name: Protected branch workflow
 
 on:
   push:
     branches:
       - master
+      - */stable
   pull_request:
     branches:
       - master
+      - */stable
 
 jobs:
   build:
@@ -16,15 +18,26 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Build snap locally
-        uses: snapcore/action-build@v1
-        id: build
-
-      - name: publish snap
-        # if: ${{ github.ref_name == 'master' }}
-        uses: snapcore/action-publish@v1
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-        with:
-          snap: ${{ steps.build.outputs.snap }}
-          release: latest/edge
+      # - name: Build snap locally
+      #   uses: snapcore/action-build@v1
+      #   id: build
+      
+      - name: Get snapcraft track
+      # if: ${{ github.ref_name == 'master' }}
+        id: track
+        run: |
+          if [ "${{ github.ref_name }}" == "master" ]; then
+            echo "::set-output name=track::master"
+          else
+            echo "::set-output name=track::$(yq -r .version snap/snapcraft.yaml)"
+          fi
+          echo "Track: ${{ steps.track.outputs.track }}"
+          
+      # - name: publish snap
+      #   # if: ${{ github.ref_name == 'master' }}
+      #   uses: snapcore/action-publish@v1
+      #   env:
+      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+      #   with:
+      #     snap: ${{ steps.build.outputs.snap }}
+      #     release: ${{ steps.track.outputs.track }}/edge

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -12,18 +12,19 @@ jobs:
   build:
     name: Build snap
     runs-on: ubuntu-latest
-    outputs:
-      snap: ${{ steps.snapcraft.outputs.snap }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Build snap locally
         uses: snapcore/action-build@v1
-        id: snapcraft
+        id: build
 
-      - name: Upload locally built snap artifact
-        uses: actions/upload-artifact@v4
+      - name: publish snap
+        # if: ${{ github.ref_name == 'master' }}
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
         with:
-          name: local-${{ steps.snapcraft.outputs.snap }}
-          path: ${{ steps.snapcraft.outputs.snap }}
+          snap: ${{ steps.build.outputs.snap }}
+          release: latest/edge

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -18,11 +18,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # - name: Build snap locally
-      #   uses: snapcore/action-build@v1
-      #   id: build
+      - name: Build snap locally
+        uses: snapcore/action-build@v1
+        id: build
       
       - name: Get snapcraft track
+        if: ${{ github.ref_protected }}
         id: track
         run: |
           if [ "${{ github.ref_name }}" == "master" ]; then
@@ -35,11 +36,11 @@ jobs:
         run: |
           echo "Track: ${{ steps.track.outputs.track }}"
           
-      # - name: publish snap
-      #   # if: ${{ github.ref_name == 'master' }}
-      #   uses: snapcore/action-publish@v1
-      #   env:
-      #     SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-      #   with:
-      #     snap: ${{ steps.build.outputs.snap }}
-      #     release: ${{ steps.track.outputs.track }}/edge
+      - name: publish snap
+        if: ${{ github.ref_protected }}
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: ${{ steps.track.outputs.track }}/edge

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,10 +32,6 @@ jobs:
             echo "::set-output name=track::$(yq -r .version snap/snapcraft.yaml)"
           fi
       
-      - name: Validate snapcraft track
-        run: |
-          echo "Track: ${{ steps.track.outputs.track }}"
-          
       - name: publish snap
         if: ${{ github.ref_protected }}
         uses: snapcore/action-publish@v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - */stable
+      - '**/stable'
   pull_request:
     branches:
       - master
-      - */stable
+      - '**/stable'
 
 jobs:
   build:
@@ -23,7 +23,6 @@ jobs:
       #   id: build
       
       - name: Get snapcraft track
-      # if: ${{ github.ref_name == 'master' }}
         id: track
         run: |
           if [ "${{ github.ref_name }}" == "master" ]; then
@@ -31,6 +30,9 @@ jobs:
           else
             echo "::set-output name=track::$(yq -r .version snap/snapcraft.yaml)"
           fi
+      
+      - name: Validate snapcraft track
+        run: |
           echo "Track: ${{ steps.track.outputs.track }}"
           
       # - name: publish snap


### PR DESCRIPTION
# Description

Publish to snapcraft.io automatically using Github workflows. The `master` branch will publish to `latest/edge` and as we create new branches for releases, we should have those publish to `<vault version>/edge`.

As of Vault `1.15`, Github runners will be used for building and publishing the Vault snap. Launchpad will continue to be used for older version of this snap.

## Rationale

### Failing Builds

Builds are [failing](https://launchpadlibrarian.net/710761134/buildlog_snap_ubuntu_jammy_amd64_vault-latest_BUILDING.txt.gz) on Launchpad, but [passing](https://github.com/canonical/snap-vault/actions/runs/7616327524/job/20742833370) using Github runners or locally. In order to get around this issue, we'd have to complexify the snapcraft.yaml content to satisfy Launchpad.

### Complexity

Having Launchpad as a separate build system complexifies the development process, we have 2 systems instead of 1 for CI. 

### Architecture supports

The only advantage of using Launchpad is building for more architectures. Currently, less than 1% of the install base is using a non amd64 architecture and most of those are on ARM. As IS adds arm Github runners, we will also build this snap for ARM using Github runners.
