### PR TITLE
fix: Use correct track name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -9,6 +9,8 @@ on:
     branches:
       - master
       - '**/stable'
+  schedule:
+    - cron: '0 6 * * 0'
 
 jobs:
   build:

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -27,7 +27,7 @@ jobs:
         id: track
         run: |
           if [ "${{ github.ref_name }}" == "master" ]; then
-            echo "::set-output name=track::master"
+            echo "::set-output name=track::latest"
           else
             echo "::set-output name=track::$(yq -r .version snap/snapcraft.yaml)"
           fi


### PR DESCRIPTION
# Description

PR #69 introduced a bug where we would publish to the `master` track instead of `latest`. We fix this issue here. We also run the CI on a schedule to regularly build and update the snap.