### PR TITLE
fix: Use correct branch name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -4,11 +4,11 @@ on:
   push:
     branches:
       - master
-      - '**/stable'
+      - 'stable/**'
   pull_request:
     branches:
       - master
-      - '**/stable'
+      - 'stable/**'
   schedule:
     - cron: '0 6 * * 0'
 


### PR DESCRIPTION
# Description

The wrong branch name selection was used in the CI. Stable branches look like `stable/1.15`, not `1.15/stable`.