### PR TITLE
fix: Take track from branch name

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -30,8 +30,12 @@ jobs:
         run: |
           if [ "${{ github.ref_name }}" == "master" ]; then
             echo "::set-output name=track::latest"
+          elif [[ "${{ github.ref_name }}" =~ ^stable\/(.+) ]]; then
+            TRACK_NAME=${BASH_REMATCH[1]}
+            echo "::set-output name=track::$TRACK_NAME"
           else
-            echo "::set-output name=track::$(yq -r .version snap/snapcraft.yaml)"
+            echo "Branch name does not match expected patterns. Exiting."
+            exit 1
           fi
       
       - name: publish snap


### PR DESCRIPTION
# Description

The track used to be taken from the version in snapcraft.yaml (ex. 1.15.4). Unfortunately, those follow 3 value semantics (x.y.z) while the snap track is a 2 value one (x.y).  This causes snap publishing to fail in `main` and in `stable/1.15`.

Here we take the track from the branch name instead of using the specific version in snapcraft.yaml

## Note

A new track was requested in Snapcraft:
- https://forum.snapcraft.io/t/vault-1-15-new-track-request/38689