### PR TITLE
chore: Bump vault version to v1.15.5

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core22
-version: 1.15.4
+version: 1.15.5
 
 grade: stable
 confinement: strict


### PR DESCRIPTION
# Description

Currently, the automation does not sign commits for bumping the Vault version ([reference PR](https://github.com/canonical/snap-vault/pull/73)) meaning that we have to create an identical PR with a signed commit like this one.

Once this is merged, #73 should be closed.