### PR TITLE
chore: bump node to 20

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ architectures:
 
 package-repositories:
  - type: apt
-   url: https://deb.nodesource.com/node_16.x
+   url: https://deb.nodesource.com/node_20.x
    components: [main]
    suites: [focal]
    key-id: 9FD3B784BC1C6FC31A8A0A1C1655A0AB68576280


### PR DESCRIPTION
# Description

Vault now uses node 20 in the upstream project and we also use this version in our rock.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
