### PR TITLE
chore: bump vault to 1.18.3

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git clone https://github.com/hashicorp/vault
           cd vault
-          RELEASE_TAG="$(git tag -l --sort=version:refname "v1.17.*" | tail -1)"
+          RELEASE_TAG="$(git tag -l --sort=version:refname "v1.18.*" | tail -1)"
           echo "::set-output name=release::${RELEASE_TAG}"
 
       - id: check

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -67,7 +67,7 @@ parts:
       - vault
       - ui
     build-snaps:
-      - go/1.22/stable
+      - go/1.23/stable
     build-packages:
       - nodejs
       - yarn

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core22
-version: 1.17.6
+version: 1.18.3
 license: BUSL-1.1
 grade: stable
 confinement: strict


### PR DESCRIPTION
# Description

Here we bump the Vault upstream revision to 1.18.3.

To do before merging this PR:
- [x] Create snap store track for 1.18
  - Snap store request: https://forum.snapcraft.io/t/create-a-1-18-track-for-the-vault-snap/44655 
- [x] Create branch for 1.17
- [ ] Point launchpad 1.17 snap to 1.17 git branch
  - I am waiting for launchpad to import the new 1.17 branch 
- [ ] Push to main
- [ ] Create launchpad 1.18 snap that points to `master` branch

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
