### PR TITLE
chore: Uses the workflow from shared workflows for Jira Sync and replaces the legacy URL with Webhook URL and Token

### DIFF
--- a/.github/workflows/jira-sync.yaml
+++ b/.github/workflows/jira-sync.yaml
@@ -7,25 +7,7 @@ on:
 jobs:
   update:
     name: Update Issue
-    runs-on: ubuntu-latest
-    steps:
-      - name: Create JIRA ticket
-        env:
-           ISSUE_TITLE: ${{ github.event.issue.title }}
-           ISSUE_DESCRIPTION: ${{ github.event.issue.body }}
-        run: |
-          if ${{ contains(github.event.*.labels.*.name, 'Bug') }}; then
-            type=bug
-          else
-            type=story
-          fi
-          data=$( jq -n \
-                  --arg title "$ISSUE_TITLE" \
-                  --arg url '${{ github.event.issue.html_url }}' \
-                  --arg submitter '${{ github.event.issue.user.login }}' \
-                  --arg body "" \
-                  --arg type "$type" \
-                  --arg action '${{ github.event.action }}' \
-                  '{title: $title, url: $url, submitter: $submitter, body: $body, type: $type, action: $action}' )
-
-          curl -X POST -H 'Content-type: application/json' --data "${data}" "${{ secrets.JIRA_URL }}"
+    uses: canonical/identity-credentials-workflows/.github/workflows/jira-sync.yaml@v0
+    secrets:
+      JIRA_WEBHOOK_URL: ${{ secrets.JIRA_WEBHOOK_URL }}
+      JIRA_WEBHOOK_TOKEN: ${{ secrets.JIRA_WEBHOOK_TOKEN }}


### PR DESCRIPTION
# Description

- Use shared workflow for issues/jira-sync
- The shared workflow replaces the legacy URL with the Webhook URL and Webhook Token

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
