### PR TITLE
chore: bump vault to v1.19.0

### DIFF
--- a/.github/workflows/auto-update.yml
+++ b/.github/workflows/auto-update.yml
@@ -28,7 +28,7 @@ jobs:
         run: |
           git clone https://github.com/hashicorp/vault
           cd vault
-          RELEASE_TAG="$(git tag -l --sort=version:refname "v1.18.*" | tail -1)"
+          RELEASE_TAG="$(git tag -l --sort=version:refname "v1.19.*" | tail -1)"
           echo "::set-output name=release::${RELEASE_TAG}"
 
       - id: check

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   is already very difficult and platform-specific. Adding on key rolling,
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
-base: core22
+base: core24
 version: 1.19.0
 license: BUSL-1.1
 grade: stable
@@ -33,18 +33,12 @@ apps:
       - network
       - network-bind
 
-architectures:
-  - build-on: [amd64]
-    build-for: [amd64]
-  - build-on: [arm64]
-    build-for: [arm64]
-  - build-on: [armhf]
-    build-for: [armhf]
-  - build-on: [ppc64el]
-    build-for: [ppc64el]
-  - build-on: [s390x]
-    build-for: [s390x]
-
+platforms:
+  amd64:
+  arm64:
+  armhf:
+  ppc64el:
+  s390x:
 
 package-repositories:
  - type: apt

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core22
-version: 1.18.5
+version: 1.19.0
 license: BUSL-1.1
 grade: stable
 confinement: strict


### PR DESCRIPTION
# Description

Bump Vault to v1.19.0. This is a new minor release. Do not merge this PR until the following tasks are completed:
- [x] Create a new `1.19` Snap store track:
  - Request here: https://forum.snapcraft.io/t/create-a-new-1-19-track-for-the-vault-snap/46212 
- [ ] Create a new `1.18` Git branch from `main`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
