### PR TITLE
chore: bump base to core24

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,7 +7,7 @@ description: |
   is already very difficult and platform-specific. Adding on key rolling,
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
-base: core22
+base: core24
 version: 1.17.6
 license: BUSL-1.1
 grade: stable


### PR DESCRIPTION
# Description

The Vault 1.17 charm will be built on the Ubuntu 24.04 base, it makes sense for its main artifact (the Vault snap) to be built on the same base. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
