### PR TITLE
chore: Update to Vault v1.20.2

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,7 +8,7 @@ description: |
   secure storage, and detailed audit logs is almost impossible without a custom
   solution. This is where Vault steps in.
 base: core24
-version: 1.19.5
+version: 1.20.2
 license: BUSL-1.1
 grade: stable
 confinement: strict


### PR DESCRIPTION

## Summary:
This PR updates the bundled HashiCorp Vault release in the snap to the latest upstream version.


## Changes:

- Updated the `version` field in `snap/snapcraft.yaml` from `1.19.5` → `1.20.2`. 
- Aligned with upstream release: [v1.20.2](https://github.com/hashicorp/vault/releases/tag/v1.20.2)
